### PR TITLE
#1 Add JSON output

### DIFF
--- a/teletext/cli/teletext.py
+++ b/teletext/cli/teletext.py
@@ -326,15 +326,31 @@ def spellcheck(packets, language, both, threads):
 @teletext.command()
 @click.option('-r', '--replace_headers', 'replace_headers', is_flag=True, default=False, help='Replace headers with a live clock.')
 @click.option('-t', '--title', 'title', type=str, default="Teletext ", help='Replace header title field with this string.')
+@click.option('--json', 'output_json', is_flag=True, default=False, help='Output the entire service as JSON instead of packets.')
 @packetwriter
 @paginated(always=True, filtered=False)
 @packetreader()
-def service(packets, replace_headers, title):
+def service(packets, replace_headers, title, output_json):
+    """
+    Build a service carousel from a t42 stream.
 
-    """Build a service carousel from a t42 stream."""
+    If --json is given, we output JSON to stdout instead of .t42 data.
+    Otherwise, we produce the usual .t42 packet output.
+    """
 
     from teletext.service import Service
-    return Service.from_packets((p for p in packets if  not p.is_padding()), replace_headers, title)
+    packets = (p for p in packets if not p.is_padding())
+    svc = Service.from_packets(packets, replace_headers, title)
+
+    if output_json:
+        json_str = svc.to_json(indent=2)
+        click.echo(json_str)
+        # Return nothing to avoid writing .t42 data:
+        return
+    else:
+        # Otherwise, yield the original .t42 packets from the service
+        # so the existing @packetwriter can handle them
+        yield from svc
 
 
 @teletext.command()

--- a/teletext/service.py
+++ b/teletext/service.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import textwrap
 
@@ -155,3 +156,49 @@ class Service(object):
                 )
                 outfile.write(template.format(page=pagestr, body=body))
 
+    def to_dict(self):
+        """
+        Return a dictionary representation of the entire Service:
+          {
+            magazine_id: {
+              'title': <magazine title>,
+              'pages': {
+                page_id: {
+                  subpage_id: { <subpage dictionary> },
+                  ...
+                },
+                ...
+              }
+            },
+            ...
+          }
+        """
+        service_dict = {}
+        for mag_id, magazine in sorted(self.magazines.items()):
+            # Convert mag_id to a plain int or string:
+            mag_key = int(mag_id)  # or str(mag_id)
+
+            pages_dict = {}
+            for page_id, page in sorted(magazine.pages.items()):
+                # Convert page_id
+                page_key = int(page_id)  # or str(page_id)
+
+                subpages_dict = {}
+                for subpage_id, subpage in sorted(page.subpages.items()):
+                    subpage_key = int(subpage_id)  # or str(subpage_id)
+                    subpages_dict[subpage_key] = subpage.to_dict()
+
+                pages_dict[page_key] = subpages_dict
+
+            service_dict[mag_key] = {
+                "title": magazine.title,
+                "pages": pages_dict,
+            }
+        return service_dict
+
+    def to_json(self, **json_kwargs):
+        """
+        Return a JSON-formatted string representing the entire service.
+        You can pass additional arguments to json.dumps via **json_kwargs.
+        """
+        return json.dumps(self.to_dict(), **json_kwargs)

--- a/teletext/subpage.py
+++ b/teletext/subpage.py
@@ -238,3 +238,47 @@ class Subpage(Element):
 
         return ''.join(lines)
 
+    def to_dict(self):
+        """Return a dictionary representation of this Subpage."""
+        return {
+            "addr": self.addr,
+            "numbers": self.numbers.tolist() if hasattr(self.numbers, "tolist") else self.numbers,
+            "checksum": int(self.checksum),
+            "header": {
+                "magazine": int(self.mrag.magazine),
+                "page": int(self.header.page),
+                "subpage": int(self.header.subpage),
+                "control": int(self.header.control),
+                "codepage": int(self.header.codepage),
+            },
+            "url": self.url,
+            "duplicates": len(self.duplicates),
+            # New field for plain text:
+            "decoded_text": self.to_text(),
+        }
+
+    def to_text(self):
+        """
+        Returns a simplistic text rendition of the 24x40 display area,
+        ignoring any teletext control codes, etc.
+        """
+        lines = []
+        # Get the 24 lines by 40 columns
+        arr = self._array[1:25, 2:]
+
+        for row_idx in range(arr.shape[0]):
+            row_data = arr[row_idx, :]
+
+            # Example naive decode: strip teletext control bit, treat as ASCII
+            text_chars = []
+            for byte_val in row_data:
+                char_val = byte_val & 0x7F
+                if 32 <= char_val < 127:
+                    text_chars.append(chr(char_val))
+                else:
+                    text_chars.append(' ')  # Replace control chars with space
+
+            line_str = ''.join(text_chars).rstrip()
+            lines.append(line_str)
+
+        return '\n'.join(lines)


### PR DESCRIPTION
Resolves #1 

- [x] Add the ability to export `JSON` data from a `.t42` file

## Testing

1. Create a virtual environment: `python3 -m venv venv` and activate it: `source venv/bin/activate`
1. Install `teletext`: `pip3 install -e ".[spellcheck,viewer]"`
1. Export your `input.t42` file to JSON: `teletext service --json < input.t42 > output.json`
1. Start a simple server: `python3 -m http.server`
1. Copy the code below to `index.html`
1. See your `JSON` visualised: http://localhost:8000
1. And the `JSON` file: http://localhost:8000/output.json

## Example output

```json
{
  "1": {
    "title": "Teletext ",
    "pages": {
      "0": {
        "1": {
          "addr": "100:0001",
          "numbers": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100
          ],
          "checksum": 45346,
          "header": {
            "magazine": 1,
            "page": 0,
            "subpage": 1,
            "control": 32,
            "codepage": 0
          },
          "url": "0:QIECBAgQIAcGrTqRbFRAxYMA9PruDsWIeD1zg2Ld0xaOmTNOdAjYKCqgpoKiCKgsIKiBAgmoIKCSgnIECCSgnIIiCKgsICyBAgQIECBAgQIECBAgQIECBAgQIECBAgQIECBAgQIECBAgTnQiBAghz6FmlJjyKiCTOjT6U2DUkz5yCfOQMWDRAgQIECAksWLFixYsWLFixYsWLFixYsWLFixYsWLFixYsWLFixYsWLAh1ADQIECBAgkzokWwgQIECBAgQIEEmdGn0qsGpKnzkCBAgJnQk2DJnIJM6JFsLly5iwYIECCNVmTEEmdEi2Fy5cuXMWDEMdCTotemuXLly5cuXLmLF0TOnUCBAgQIECBAgQIECBAgQICh0NToT6VRcuXLly5cuYtmBM6Eg1adSLYqIJEWZQXLlzFgyKHQ1eLBqSItJcuXLly5i4YEzoRAgQIECBAgQIECBAgQIECAodDRpM6DOhxVy5cuXLmTBgTOhIMStFpVJNOTWjrly5cxYMyh0NUrIKFKfHpQZtNcuZsGBM6TWLFixYsWLFixYsWLFixYsKHQyBAgQIECBAgQIECBAgQEzoSHPoWaUmPIqIJM6NPXMWDQodDVIMJBTi0q0mHFXLmrBgTOoECBAgQIECBAgQIECBAgQICh0NHi1otKDMQSZ0aeubMGBM6EqT6CCpFsVEEmdGnrlzFg1KHQyBAgQIECBAgQIECBAgQEzt27duoECBAgQIECBAgQIECAoQDQatOpFsVEFaLXprmzBoTOhKdCfOpz6SCTWiRbC5cxYNih0NMn1KkWlJi01y5cubMWCBAgQIECBAgQIECBAgQIECBAgKHQ0elFi1JNbHTXLly5syYIECBAgQIECBAgQIECBAgQIECAodDS5MSmgXLly5cuXLmzdgTQIECBAgQIECBAgQIECBAgQIChANDg0KkmfWqoFy5cucMGJNAgQIECBAgQIECBAgQIECBAgCHUCAEDGzsPTTv3YdiCLsy4-nLTj09PKCbh5a8vRAgQIECAitDoJsWnVwR4qBcuQRINSK6YNlsaLCWuWyBAghadmxAgQIAh1AgQIECBAgQA6cWKgoQY8VAybOECtAybsECBAgQIECBAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:PN=100:PS=10:SC=1",
          "duplicates": 0,
          "decoded_text": "'   A U S T E X T   M A I N   I N D E X\n\n'     COPYRIGHT INFORMATION ON 104\n ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,\n          INDEX          INFORUATJON\n   MAIN INDEX...100   FULL INDEX.....101\n   NEWS.........11:\n   SPORT........160   AUSTEXT HELP...102\n   WEATHER......180\n   FINANCE......200   ADVERTISIVG....103\n   TV PROGRAMS..300   ,,,,,,,,,,,,,,,,,,\n                      COPYRIGHT INFO.104\n   TAB SERVICE..500\n   GEVERAL INFO.600   TOP TEXT INFO..105\n                     ]]]]\n   AUSTEXT VEWS.604   SPONSOR IVDEX..106\n   LOTTERIES....610\n   GREETIVcS....620\n   KIDS ........670\n   CAPTIOVU ....801\n       National Electricity Market\n -  MESU`GE .. DATE:06-FEB-96   Bill\n            SEE PAGE 268 + 270\n"
        }
      }
    }
  }
}

```

## Visualisation code

```html
<!-- index.html -->
<!DOCTYPE html>
<html>
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <title>Teletext JSON Viewer</title>
  <style>
    body {
      background-color: black;
      margin: 0;
      padding: 0;
    }
    .teletext {
      font-family: monospace;
      white-space: pre;
      font-size: 16px;
      color: white;
      background-color: black;
      padding: 10px;
    }
    #loading {
      position: absolute;
      top: 50%;
      left: 50%;
      transform: translate(-50%, -50%);
      display: block;
    }
    .loading-block {
      animation: colorCycle 2s infinite;
    }
    @keyframes colorCycle {
      0% { color: #FF0000; }   /* red */
      14% { color: #00FF00; }  /* green */
      28% { color: #FFFF00; }  /* yellow */
      42% { color: #0000FF; }  /* blue */
      57% { color: #FF00FF; }  /* magenta */
      71% { color: #00FFFF; }  /* cyan */
      85% { color: #FFFFFF; }  /* white */
      100% { color: #FF0000; } /* red */
    }
    .container {
      margin: 1rem;
    }
    .page-heading {
      color: #ccc;
      margin-top: 2rem;
    }
  </style>
</head>
<body>
  <!-- LOADING INDICATOR -->
  <div id="loading">
    <pre class="teletext">
      <span style="color: #FF0000;">L</span><span style="color: #00FF00;">O</span><span style="color: #FFFF00;">A</span><span style="color: #0000FF;">D</span><span style="color: #FF00FF;">I</span><span style="color: #00FFFF;">N</span><span style="color: #FFFFFF;">G</span>
      <span class="loading-block">█</span>
    </pre>
  </div>

  <!-- MAIN CONTAINER FOR CONTENT -->
  <div id="viewer" class="container"></div>

  <script>
  (function() {
    // Hide/show the loading indicator
    function setLoading(visible) {
      document.getElementById('loading').style.display = visible ? 'block' : 'none';
    }

    // On page load, fetch the JSON
    setLoading(true);

    fetch('output.json')  // <-- change filename if needed
      .then(response => {
        if (!response.ok) {
          throw new Error('Network response was not OK');
        }
        return response.json();
      })
      .then(data => {
        // data should be the dictionary from service.to_dict()
        // which typically looks like:
        // {
        //   "1": {
        //     "title": "...",
        //     "pages": {
        //       "100": {
        //         "0": { ...subpage dict... },
        //         "1": { ...subpage dict... },
        //         ...
        //       },
        //       "101": { ... },
        //       ...
        //     }
        //   },
        //   "2": { ... },
        //   ...
        // }

        const viewer = document.getElementById('viewer');

        // Loop magazines
        for (const [magId, magazineObj] of Object.entries(data)) {
          const magTitle = magazineObj.title || `Magazine ${magId}`;
          // Create a heading for the magazine
          const magHeading = document.createElement('h1');
          magHeading.textContent = `Magazine ${magId} — ${magTitle}`;
          magHeading.style.color = 'white';
          viewer.appendChild(magHeading);

          // Loop pages
          const pages = magazineObj.pages || {};
          for (const [pageId, subpagesObj] of Object.entries(pages)) {
            // subpagesObj is { subpageNumber: <subpageDict> }
            for (const [subpageId, subpageDict] of Object.entries(subpagesObj)) {
              // Each subpage has, e.g.: { decoded_text, url, ... }

              // Create a heading for the page / subpage
              const pageHeading = document.createElement('h2');
              pageHeading.textContent = `Page: ${pageId}, Subpage: ${subpageId}, addr: ${subpageDict.addr}`;
              pageHeading.className = 'page-heading';
              viewer.appendChild(pageHeading);

              // Add a <pre> block with the subpage's decoded text
              const preEl = document.createElement('pre');
              preEl.className = 'teletext';
              if (subpageDict.decoded_text) {
                preEl.textContent = subpageDict.decoded_text;
              } else {
                preEl.textContent = '(No decoded_text available)';
              }
              viewer.appendChild(preEl);
            }
          }
        }

        setLoading(false);
      })
      .catch(error => {
        setLoading(false);
        console.error('Error loading JSON:', error);
        document.getElementById('loading').innerHTML =
          '<pre class=\"teletext\" style=\"color: red;\">Error loading JSON<br>' + error + '</pre>';
      });
  })();
  </script>
</body>
</html>

```